### PR TITLE
Fixes (openacc pragmas, multiple target support, warmup phase, ...)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,8 +15,16 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "PGI")
   message(">>> Setting compiler flags for PGI compiler...")
-  #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Minfo=accel -acc -ta=nvidia:kepler -ta=host")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Minfo=accel -acc -ta=nvidia:kepler")
-endif()
+  add_executable(${PROJECT_NAME} ${SOURCES})
+  set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-ta=host")
 
-add_executable(${PROJECT_NAME} ${SOURCES})
+  add_executable(${PROJECT_NAME}_kepler ${SOURCES})
+  set_target_properties(${PROJECT_NAME}_kepler PROPERTIES
+    COMPILE_FLAGS "-Minfo=accel -acc -ta=nvidia:kepler"
+    LINK_FLAGS "-laccapi -laccg -laccn -laccg2 -ldl")
+
+  add_executable(${PROJECT_NAME}_multicore ${SOURCES})
+  set_target_properties(${PROJECT_NAME}_multicore PROPERTIES
+    COMPILE_FLAGS "-Minfo=accel -acc -ta=multicore"
+    LINK_FLAGS "-laccapi -laccg -laccn -laccg2 -ldl")
+endif()


### PR DESCRIPTION
- cmake multiple targets for host, multicore and kepler device (removed ifdefs in popcorn2d.cpp). 
- fixed talpha glitch. 
- fixed openacc directives. 
- warmup step added. 
- _(code has not been tested on kepler gpu yet.)_

feel free to merge and to continue your work based on my suggestions for the OpenACC pragmas. 
The data part has been moved to the acc data pragma so we could also parallelize colorImage while reusing data buffer on GPU.
I used acc parallel instead of acc kernels, but you should do some experiments. Also bear in mind that atomics have not been used yet, so computation is still incorrect.

*Targets*
```
make popcorn2d            # host code without any accelerations
make popcorn2d_multicore  # for multicore acceleration
make popcorn2d_kepler     # for kepler GPU acceleration
make                      # creates all makefile targets from above
```